### PR TITLE
Enhancement/0419 로그인 딜레이 수정, 새탭 열기, 지도 개선

### DIFF
--- a/apps/frontend/src/app/(auth)/login/page.tsx
+++ b/apps/frontend/src/app/(auth)/login/page.tsx
@@ -1,11 +1,9 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
 import Image from "next/image";
 
 export default function LoginPage() {
-  const router = useRouter();
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
@@ -35,11 +33,9 @@ export default function LoginPage() {
         return;
       }
 
-      router.push("/");
-      router.refresh();
+      window.location.href = "/";
     } catch {
       setError("서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요.");
-    } finally {
       setLoading(false);
     }
   }

--- a/apps/frontend/src/app/(main)/devices/[id]/page.tsx
+++ b/apps/frontend/src/app/(main)/devices/[id]/page.tsx
@@ -41,6 +41,7 @@ export default async function DeviceDetailPage({ params }: Props) {
               {siteId ? (
                 <Link
                   href={`/sites/${encodeURIComponent(siteId)}`}
+                  target="_blank"
                   className="breadcrumb-item"
                 >
                   {site?.name ?? "현장"}

--- a/apps/frontend/src/app/(main)/layout.tsx
+++ b/apps/frontend/src/app/(main)/layout.tsx
@@ -103,7 +103,7 @@ export default async function MainLayout({
           {user && (
             <div className="header-user-info">
               {user.role === "ADMIN" ? (
-                <Link href="/admin" className="global-header-admin-link">
+                <Link href="/admin" target="_blank" className="global-header-admin-link">
                   관리자 패널
                 </Link>
               ) : (

--- a/apps/frontend/src/app/(main)/sites/[siteId]/page.tsx
+++ b/apps/frontend/src/app/(main)/sites/[siteId]/page.tsx
@@ -141,6 +141,7 @@ export default async function SitePage({ params }: Props) {
             <Link
               key={inst.id}
               href={`/devices/${encodeURIComponent(inst.id)}`}
+              target="_blank"
               className="site-inst-card"
             >
               <div className="site-inst-top">

--- a/apps/frontend/src/components/AppNav/AppNav.tsx
+++ b/apps/frontend/src/components/AppNav/AppNav.tsx
@@ -93,6 +93,7 @@ export default function AppNav() {
           <Link
             key={item.href}
             href={item.href}
+            target="_blank"
             className={`app-nav-item${isActive(item.href) ? " active" : ""}`}
           >
             <span className="app-nav-icon">{item.icon}</span>

--- a/apps/frontend/src/components/Dashboard/DashboardAccordion.tsx
+++ b/apps/frontend/src/components/Dashboard/DashboardAccordion.tsx
@@ -115,6 +115,7 @@ export default function DashboardAccordion({ regionEntries, selectedRegion }: Pr
                         key={site.id}
                         className="region-device-card"
                         href={`/sites/${encodeURIComponent(site.id)}`}
+                        target="_blank"
                       >
                         <div className="region-device-top">
                           <strong className="region-title">

--- a/apps/frontend/src/components/Dashboard/KoreaMap.tsx
+++ b/apps/frontend/src/components/Dashboard/KoreaMap.tsx
@@ -136,12 +136,14 @@ const CITY_COORDS: Record<string, [number, number]> = {
   동구: [127.46, 36.31],
   중구: [127.42, 36.33],
   // 경기도 시 단위
-  안양시: [126.95, 37.39],
+  안양시: [126.92, 37.40],
   수원시: [127.0, 37.26],
   성남시: [127.13, 37.42],
-  화성시: [127.07, 37.2],
+  화성시: [127.10, 37.18],
+  동탄: [127.07, 37.20],
   용인시: [127.18, 37.24],
-  고양시: [126.83, 37.66],
+  고양시: [126.77, 37.66],
+  일산: [126.77, 37.68],
   평택시: [127.09, 36.99],
   파주시: [126.78, 37.76],
   김포시: [126.72, 37.62],
@@ -210,14 +212,16 @@ function resolveCoords(
   const parts = address
     .replace(/특별시|광역시|특별자치시|특별자치도/g, "")
     .split(/\s+/);
+  // 1) 부분 매칭 — 주소 전체에서 가장 긴 키를 먼저 선택 (더 구체적인 지역 우선)
+  const allKeys = Object.keys(CITY_COORDS).sort(
+    (a, b) => b.length - a.length,
+  );
+  for (const key of allKeys) {
+    if (address.includes(key)) return CITY_COORDS[key];
+  }
+  // 2) part별 정확 매칭 폴백
   for (const part of parts) {
     if (CITY_COORDS[part]) return CITY_COORDS[part];
-  }
-  for (const part of parts) {
-    const match = Object.keys(CITY_COORDS).find(
-      (k) => part.includes(k) || k.includes(part),
-    );
-    if (match) return CITY_COORDS[match];
   }
   return CITY_COORDS[region] ?? null;
 }

--- a/apps/frontend/src/components/Dashboard/KoreaMap.tsx
+++ b/apps/frontend/src/components/Dashboard/KoreaMap.tsx
@@ -39,11 +39,11 @@ const GEO_TO_REGION: Record<string, string> = {
 type StatusStyle = { active: string; selected: string; stroke: string };
 
 const STATUS_STYLE: Record<DeviceStatus, StatusStyle> = {
-  running: { active: "#0a2e14", selected: "#0f4520", stroke: "#34C759" },
-  standby: { active: "#2a1e00", selected: "#3d2c00", stroke: "#F59E0B" },
-  start: { active: "#2a1e00", selected: "#3d2c00", stroke: "#F59E0B" },
-  fault: { active: "#2d0a0a", selected: "#3f0e0e", stroke: "#EF4444" },
-  offline: { active: "#161e2c", selected: "#1e2840", stroke: "#4B5563" },
+  running: { active: "#0a2e14", selected: "#0f4520", stroke: "#5ee986" },
+  standby: { active: "#2a1e00", selected: "#3d2c00", stroke: "#fcd34d" },
+  start: { active: "#2a1e00", selected: "#3d2c00", stroke: "#fcd34d" },
+  fault: { active: "#2d0a0a", selected: "#3f0e0e", stroke: "#f87171" },
+  offline: { active: "#161e2c", selected: "#1e2840", stroke: "#9ca3af" },
 };
 
 function lerpColor(a: string, b: string, t: number): string {
@@ -70,7 +70,7 @@ function regionHealthColors(stats: RegionStats): {
 } {
   const { total, counts } = stats;
   if (total === 0)
-    return { fill: "#161e2c", fillSelected: "#1e2840", stroke: "#4B5563" };
+    return { fill: "#161e2c", fillSelected: "#1e2840", stroke: "#9ca3af" };
 
   const okRatio = (counts.running ?? 0) / total;
   const faultRatio = (counts.fault ?? 0) / total;
@@ -85,21 +85,21 @@ function regionHealthColors(stats: RegionStats): {
       Math.min(faultRatio * 3, 1),
     );
     const stroke = lerpColor(
-      "#34C759",
-      "#EF4444",
+      "#5ee986",
+      "#f87171",
       Math.min(faultRatio * 2.5, 1),
     );
     return { fill, fillSelected: fillSel, stroke };
   }
   if (okRatio >= 0.8)
-    return { fill: "#0a2e14", fillSelected: "#0f4520", stroke: "#34C759" };
+    return { fill: "#0a2e14", fillSelected: "#0f4520", stroke: "#5ee986" };
   if (okRatio >= 0.5) {
     const fill = lerpColor("#0a2e14", "#2a1e00", 1 - okRatio);
     const fillSel = lerpColor("#0f4520", "#3d2c00", 1 - okRatio);
-    const stroke = lerpColor("#34C759", "#F59E0B", 1 - okRatio);
+    const stroke = lerpColor("#5ee986", "#fcd34d", 1 - okRatio);
     return { fill, fillSelected: fillSel, stroke };
   }
-  return { fill: "#2a1e00", fillSelected: "#3d2c00", stroke: "#F59E0B" };
+  return { fill: "#2a1e00", fillSelected: "#3d2c00", stroke: "#fcd34d" };
 }
 
 const STATUS_DOT: Record<DeviceStatus, string> = {
@@ -222,7 +222,7 @@ function resolveCoords(
   return CITY_COORDS[region] ?? null;
 }
 
-const INITIAL_CENTER: [number, number] = [127.8, 36.0];
+const INITIAL_CENTER: [number, number] = [127.8, 35.52];
 const INITIAL_ZOOM = 1;
 const ZOOM_STEP = 1.6;
 const MIN_ZOOM = 1;
@@ -371,7 +371,7 @@ export default function KoreaMap({
 
       <ComposableMap
         projection="geoMercator"
-        projectionConfig={{ center: [127.8, 36.0], scale: 3000 }}
+        projectionConfig={{ center: [127.8, 35.7], scale: 3000 }}
         width={300}
         height={400}
         style={{ width: "100%", height: "100%" }}
@@ -381,7 +381,9 @@ export default function KoreaMap({
           center={center}
           minZoom={MIN_ZOOM}
           maxZoom={MAX_ZOOM}
-          {...{ filterZoomEvent: (evt: { type: string }) => evt.type !== "wheel" } as Record<string, unknown>}
+          {...({
+            filterZoomEvent: (evt: { type: string }) => evt.type !== "wheel",
+          } as Record<string, unknown>)}
           onMoveEnd={({ zoom: z, coordinates }) => {
             setZoom(z);
             setCenter(coordinates);
@@ -403,18 +405,18 @@ export default function KoreaMap({
                       geography={geo}
                       style={{
                         default: {
-                          fill: "#0e1118",
-                          stroke: "#1a2030",
-                          strokeWidth: 0.4,
+                          fill: "#161c28",
+                          stroke: "rgba(203, 213, 225, 0.55)",
+                          strokeWidth: 0.5,
                           outline: "none",
                         },
                         hover: {
-                          fill: "#141b28",
-                          stroke: "#1a2030",
-                          strokeWidth: 0.4,
+                          fill: "#1c2433",
+                          stroke: "rgba(226, 232, 240, 0.72)",
+                          strokeWidth: 0.95,
                           outline: "none",
                         },
-                        pressed: { fill: "#0e1118", outline: "none" },
+                        pressed: { fill: "#161c28", outline: "none" },
                       }}
                     />
                   );
@@ -462,14 +464,14 @@ export default function KoreaMap({
                       default: {
                         fill,
                         stroke: colors.stroke,
-                        strokeWidth: isSelected ? 1.2 : 0.7,
+                        strokeWidth: isSelected ? 1.45 : 1.05,
                         outline: "none",
                         cursor: "pointer",
                       },
                       hover: {
                         fill: colors.fillSelected,
                         stroke: colors.stroke,
-                        strokeWidth: 1.2,
+                        strokeWidth: 1.45,
                         outline: "none",
                         cursor: "pointer",
                       },

--- a/apps/frontend/src/components/Dashboard/SiteSummaryPanel.tsx
+++ b/apps/frontend/src/components/Dashboard/SiteSummaryPanel.tsx
@@ -107,6 +107,7 @@ export default function SiteSummaryPanel({ site }: { site: Site | null }) {
             <Link
               key={inst.id}
               href={`/devices/${encodeURIComponent(inst.id)}`}
+              target="_blank"
               className="summary-inst-card"
             >
               <div className="summary-inst-header">
@@ -150,6 +151,7 @@ export default function SiteSummaryPanel({ site }: { site: Site | null }) {
       {/* Footer link */}
       <Link
         href={`/sites/${encodeURIComponent(site.id)}`}
+        target="_blank"
         className="summary-more-link"
       >
         현장 상세보기 →

--- a/apps/frontend/src/components/InstallationSummary/InstallationSummaryCard.tsx
+++ b/apps/frontend/src/components/InstallationSummary/InstallationSummaryCard.tsx
@@ -39,6 +39,7 @@ export default function InstallationSummaryCard({
   return (
     <Link
       href={`/devices/${encodeURIComponent(installationId)}`}
+      target="_blank"
       className="device-card"
     >
       {/* Header */}


### PR DESCRIPTION
## Summary
- 로그인 후 3초 딜레이 제거 (router.push → window.location.href)
- 모든 내부 링크 새 탭에서 열기 (홈 버튼 제외)
- 제주도 설치현장 추가 (Dev DB)
- 경기도 지도 dot 도시별 분리 (동탄/일산/안양 좌표 분산)
- Fault 상태 설치지점 3곳에 실제 Fault 이벤트 데이터 추가 (Dev DB)

## Test plan
- [ ] 로그인 후 스피너 → 메인화면 즉시 전환 확인
- [ ] 카드/링크 클릭 시 새 탭 열림 확인 (홈 버튼 제외)
- [ ] 지도에서 제주도 dot 확인
- [ ] 경기도 3개 dot 구분 확인
- [ ] 대구 롯데캐슬, 대구 테크노 DC, 청라 자이 → Faults 탭 이력 확인