### PR TITLE
Add page-specific tab titles for better tab identification

### DIFF
--- a/apps/frontend/src/app/(auth)/layout.tsx
+++ b/apps/frontend/src/app/(auth)/layout.tsx
@@ -1,4 +1,7 @@
 import type { ReactNode } from "react";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = { title: "로그인" };
 
 export default function AuthLayout({ children }: { children: ReactNode }) {
   return <div className="auth-layout">{children}</div>;

--- a/apps/frontend/src/app/(main)/admin/layout.tsx
+++ b/apps/frontend/src/app/(main)/admin/layout.tsx
@@ -1,5 +1,8 @@
 import type { ReactNode } from "react";
+import type { Metadata } from "next";
 import { cookies } from "next/headers";
+
+export const metadata: Metadata = { title: "관리자 패널" };
 import { redirect } from "next/navigation";
 import AdminNav from "../../../components/Admin/AdminNav";
 

--- a/apps/frontend/src/app/(main)/devices/[id]/page.tsx
+++ b/apps/frontend/src/app/(main)/devices/[id]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { fetchDevice, fetchReadings, fetchFaults } from "../../../../lib/api";
@@ -8,6 +9,13 @@ import type { DeviceWithInstallation } from "../../../../types/site";
 type Props = {
   params: { id: string };
 };
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const device = await fetchDevice(decodeURIComponent(params.id)) as DeviceWithInstallation | null;
+  const label = device?.installation?.label ?? "장비 상세";
+  const siteName = device?.installation?.site?.name;
+  return { title: siteName ? `${label} - ${siteName}` : label };
+}
 
 const HISTORY_HOURS = 24;
 

--- a/apps/frontend/src/app/(main)/page.tsx
+++ b/apps/frontend/src/app/(main)/page.tsx
@@ -1,5 +1,8 @@
+import type { Metadata } from "next";
 import { fetchSites } from "../../lib/api";
 import DashboardClient from "../../components/Dashboard/DashboardClient";
+
+export const metadata: Metadata = { title: "대시보드" };
 
 export default async function HomePage() {
   const sites = await fetchSites().catch(() => []);

--- a/apps/frontend/src/app/(main)/sites/[siteId]/page.tsx
+++ b/apps/frontend/src/app/(main)/sites/[siteId]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { fetchSites } from "../../../../lib/api";
 import type { Device, DeviceStatus } from "../../../../types/site";
@@ -6,6 +7,12 @@ import { CLIENT_LABELS } from "../../../../data/clients";
 type Props = {
   params: { siteId: string };
 };
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const sites = await fetchSites();
+  const site = sites.find((s) => s.id === decodeURIComponent(params.siteId));
+  return { title: site?.name ?? "현장 상세" };
+}
 
 const statusPriority: Record<DeviceStatus, number> = {
   fault: 4,

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -3,7 +3,10 @@ import type { ReactNode } from "react";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "PrimeSolution PMCS",
+  title: {
+    default: "PrimeSolution PMCS",
+    template: "%s | PMCS",
+  },
   description: "Power Monitoring and Control System",
   icons: { icon: "/favicon.png" },
 };


### PR DESCRIPTION
Each page now shows a distinct browser tab title:
- 대시보드 | PMCS
- 로그인 | PMCS
- {현장명} | PMCS (e.g. 송도 크리스탈자이 | PMCS)
- {설치지점} - {현장명} | PMCS (e.g. 101동 변전실 - 송도 크리스탈자이 | PMCS)
- 관리자 패널 | PMCS