### PR TITLE
Fix login failure spinner not stopping

### DIFF
--- a/apps/frontend/src/app/(auth)/login/page.tsx
+++ b/apps/frontend/src/app/(auth)/login/page.tsx
@@ -30,6 +30,7 @@ export default function LoginPage() {
 
       if (!res.ok) {
         setError(data.message ?? "로그인에 실패했습니다.");
+        setLoading(false);
         return;
       }
 


### PR DESCRIPTION
setLoading(false) was missing in the !res.ok branch, causing infinite spinner on wrong credentials.