### PR TITLE
Create empty Device record when adding a new installation

### DIFF
--- a/apps/backend/src/services/siteService.ts
+++ b/apps/backend/src/services/siteService.ts
@@ -97,7 +97,7 @@ export const siteService = {
     return true;
   },
 
-  /* ─── 설치지점 생성 ─────────────────────────────── */
+  /* ─── 설치지점 생성 (빈 Device도 함께 생성) ──────── */
   createInstallation: async (data: {
     id?: string;
     siteId: string;
@@ -105,9 +105,13 @@ export const siteService = {
   }) => {
     const id = data.id?.trim();
     if (!id) throw new Error("Installation id is required");
-    return prisma.installation.create({
+    const installation = await prisma.installation.create({
       data: { id, siteId: data.siteId, label: data.label },
     });
+    await prisma.device.create({
+      data: { installationId: id, lastIp: "unknown" },
+    });
+    return installation;
   },
 
   /* ─── 설치지점 삭제 (Device/Telemetry cascade) ─── */


### PR DESCRIPTION
Fixes 404 when clicking a newly added installation that has no device data yet. Also backfilled the existing prime-parking-lot-1 record directly in the database.