### PR TITLE
enhancement/0618: 보안 헤더 적용 (FE+BE) (#1)

### DIFF
--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -79,6 +79,20 @@ export const buildServer = async (env: Env) => {
   /* ── WebSocket ────────────────────────────────── */
   await server.register(websocket);
 
+  /* ── 보안 헤더 (모든 응답) ─────────────────────────
+   * API 서버이므로 프레임 차단(DENY)·nosniff·HSTS·referrer 최소화.
+   * CORS 는 위 fastifyCors 가 처리하므로 CORP 는 설정하지 않는다(교차 출처 FE 차단 방지). */
+  server.addHook("onSend", async (_request, reply, payload) => {
+    reply.header("X-Content-Type-Options", "nosniff");
+    reply.header("X-Frame-Options", "DENY");
+    reply.header("Referrer-Policy", "no-referrer");
+    reply.header("Strict-Transport-Security", "max-age=63072000; includeSubDomains");
+    reply.header("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
+    reply.header("X-DNS-Prefetch-Control", "off");
+    reply.removeHeader("X-Powered-By");
+    return payload;
+  });
+
   /* ── Routes ───────────────────────────────────── */
   await server.register(healthRoutes, { prefix: "/health" });
   await server.register(authRoutes, { prefix: "/auth" });

--- a/netlify.toml
+++ b/netlify.toml
@@ -13,3 +13,15 @@
 [context.dev.environment]
   NEXT_PUBLIC_API_BASE = "https://pmcsbackend-dev.up.railway.app"
   COMMAND_API_BASE = "https://pmcsbackend-dev.up.railway.app"
+
+# 보안 헤더 (모든 경로)
+# CSP 는 인라인 스크립트/지도/3rd-party 영향이 커 별도 신중 적용 — 여기서는 제외.
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "SAMEORIGIN"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Strict-Transport-Security = "max-age=63072000; includeSubDomains; preload"
+    Permissions-Policy = "camera=(), microphone=(), geolocation=(), interest-cohort=()"
+    X-DNS-Prefetch-Control = "off"


### PR DESCRIPTION
- netlify.toml: 모든 경로에 보안 헤더 추가 (X-Frame-Options, X-Content-Type-Options, Referrer-Policy, HSTS, Permissions-Policy, X-DNS-Prefetch-Control)
- server.ts: onSend 훅으로 모든 API 응답에 동일 계열 보안 헤더 + X-Powered-By 제거 (CORS 유지 위해 CORP 미설정). 의존성 추가 없음
- CSP 는 인라인 스크립트/지도 영향으로 별도 신중 적용 예정