### PR TITLE
fix: dev/prod 환경 분리 복구 + CORS origin 정규화

### DIFF
--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -23,13 +23,32 @@ declare module "@fastify/jwt" {
   }
 }
 
+/** 쉼표로 구분된 origin 목록을 정규화한다.
+ * 후행 슬래시가 붙은 값(`https://foo.app/`)은 브라우저가 보내는 Origin 헤더와
+ * 절대 일치하지 않아 CORS 가 조용히 깨진다 — 여기서 떼어낸다. */
+export const parseAllowedOrigins = (value: string): string[] => [
+  ...new Set(
+    value
+      .split(",")
+      .map((origin) => origin.trim().replace(/\/+$/, ""))
+      .filter((origin) => origin.length > 0),
+  ),
+];
+
 const envSchema = z.object({
   PORT: z.number().int().positive(),
   HOST: z.string().min(1),
   DATABASE_URL: z.string().min(1),
   JWT_SECRET: z.string().min(16),
   RECEIVER_API_KEY: z.string().min(8),
-  FRONTEND_ORIGIN: z.string().min(1),
+  // 환경별로 여러 개를 허용한다 (예: dev 백엔드에 dev 사이트 + localhost).
+  FRONTEND_ORIGIN: z
+    .string()
+    .min(1)
+    .transform(parseAllowedOrigins)
+    .refine((origins) => origins.length > 0, {
+      message: "FRONTEND_ORIGIN 에 유효한 origin 이 없습니다",
+    }),
 });
 
 export type Env = z.infer<typeof envSchema>;
@@ -60,6 +79,9 @@ export const buildServer = async (env: Env) => {
   );
 
   /* ── CORS ─────────────────────────────────────── */
+  // 허용 origin 을 부팅 로그에 남긴다 — 환경변수 오타는 런타임에 조용히 실패하므로
+  // 로그에 찍힌 목록이 dev/prod 를 잘못 물었는지 확인하는 가장 빠른 단서가 된다.
+  server.log.info({ allowedOrigins: env.FRONTEND_ORIGIN }, "CORS allowed origins");
   await server.register(fastifyCors, {
     origin: env.FRONTEND_ORIGIN,
     credentials: true,

--- a/netlify.toml
+++ b/netlify.toml
@@ -11,8 +11,18 @@
 
 # Dev 환경변수 (dev 브랜치)
 [context.dev.environment]
-  NEXT_PUBLIC_API_BASE = "https://pmcsbackend-production.up.railway.app"
-  COMMAND_API_BASE = "https://pmcsbackend-production.up.railway.app"
+  NEXT_PUBLIC_API_BASE = "https://pmcsbackend-dev.up.railway.app"
+  COMMAND_API_BASE = "https://pmcsbackend-dev.up.railway.app"
+
+# main 외 브랜치 배포 / PR 프리뷰도 dev 백엔드로 — 미지정 시 Netlify UI 값(prod)으로
+# 폴백해서 프리뷰가 실서비스 DB를 건드리게 된다.
+[context.branch-deploy.environment]
+  NEXT_PUBLIC_API_BASE = "https://pmcsbackend-dev.up.railway.app"
+  COMMAND_API_BASE = "https://pmcsbackend-dev.up.railway.app"
+
+[context.deploy-preview.environment]
+  NEXT_PUBLIC_API_BASE = "https://pmcsbackend-dev.up.railway.app"
+  COMMAND_API_BASE = "https://pmcsbackend-dev.up.railway.app"
 
 # 보안 헤더 (모든 경로)
 # CSP 는 인라인 스크립트/지도/3rd-party 영향이 커 별도 신중 적용 — 여기서는 제외.


### PR DESCRIPTION
netlify.toml:
- dev 컨텍스트가 prod 백엔드를 가리키던 것을 dev 백엔드로 되돌린다. b673f82 에서 되돌려진 뒤 dev 사이트가 실서비스 백엔드/DB 를 물고 있었다. Netlify 는 배포 대상 브랜치의 netlify.toml 을 읽으므로 main 에 남아있던 올바른 값은 dev 배포에 쓰이지 않았다.
- branch-deploy / deploy-preview 컨텍스트를 추가한다. 미지정 시 Netlify UI 값(prod)으로 폴백해 PR 프리뷰가 실서비스 DB 를 건드린다.

server.ts:
- FRONTEND_ORIGIN 의 후행 슬래시를 제거한다. 현재 prod/dev 양쪽 모두 `https://lmacs.netlify.app/` 로 설정돼 있어 브라우저 Origin 헤더와 절대 매칭되지 않는다. 대부분의 호출이 Next.js Route Handler 경유라 드러나지 않았을 뿐이다.
- 쉼표 구분 다중 origin 을 허용해 dev 백엔드에 dev 사이트와 localhost 를 함께 등록할 수 있게 한다.
- 유효 origin 이 하나도 없으면 부팅을 실패시키고, 허용 목록을 부팅 로그에 남긴다.