### PR TITLE
fix: require x-api-key on HMI fault POST endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ STM32 + Quectel LTE 장비의 다운링크 명령 제어는 아래 4개 API로 �
 
 아래 장비 엔드포인트는 `x-api-key: <RECEIVER_API_KEY>` 필수:
 - `POST /receiver`
+- `POST /receiver/faults`
+- `POST /receiver/faults/critical`
 - `GET /receiver/commands`
 - `POST /receiver/commands/ack`
 

--- a/apps/backend/src/lib/env.ts
+++ b/apps/backend/src/lib/env.ts
@@ -1,5 +1,21 @@
-import { parseEnv } from "../server.js";
+import { z } from "zod";
+import { EnvConfigError, parseEnv } from "../server.js";
 
 export const loadEnv = () => {
-  return parseEnv(process.env);
+  try {
+    return parseEnv(process.env);
+  } catch (error) {
+    if (error instanceof EnvConfigError) {
+      console.error(`\n🚨 환경변수 설정 오류\n${error.message}\n`);
+      process.exit(1);
+    }
+    if (error instanceof z.ZodError) {
+      const details = error.issues
+        .map((issue) => `  · ${issue.path.join(".") || "(root)"}: ${issue.message}`)
+        .join("\n");
+      console.error(`\n🚨 환경변수 검증 실패\n${details}\n`);
+      process.exit(1);
+    }
+    throw error;
+  }
 };

--- a/apps/backend/src/routes/health.ts
+++ b/apps/backend/src/routes/health.ts
@@ -6,7 +6,7 @@ export const healthRoutes: FastifyPluginAsync = async (server) => {
       status: "ok",
       timestamp: new Date().toISOString(),
       // bump when verifying Railway actually picked up a new deploy
-      build: "settings-lte-v1",
+      build: "receiver-auth-v2",
     };
   });
 };

--- a/apps/backend/src/routes/receiver.ts
+++ b/apps/backend/src/routes/receiver.ts
@@ -194,17 +194,12 @@ export const receiverRoutes: FastifyPluginAsync<ReceiverOptions> = async (
   opts,
 ) => {
   const apiKey = opts.receiverApiKey;
-  const authByApiKey = (
-    request: { headers: Record<string, unknown> },
-    reply: { status: (code: number) => { send: (body: unknown) => unknown } },
-  ) => {
+  /** 응답은 호출자가 보낸다 — 여기서도 보내면 이중 send 로 ERR_HTTP_HEADERS_SENT 가 터져
+   *  프로세스가 죽는다(잘못된 키 요청 한 번으로 서버 다운). */
+  const hasValidApiKey = (request: { headers: Record<string, unknown> }) => {
     const providedKey =
       (request.headers["x-api-key"] as string | undefined) ?? "";
-    if (providedKey !== apiKey) {
-      reply.status(401).send({ message: "Unauthorized" });
-      return false;
-    }
-    return true;
+    return providedKey === apiKey;
   };
 
   const notifyCriticalFault = (payload: {
@@ -240,7 +235,7 @@ export const receiverRoutes: FastifyPluginAsync<ReceiverOptions> = async (
 
   /* 더 구체적인 경로를 먼저 등록 (POST /faults 가 /faults/critical 을 가리지 않도록) */
   server.post("/faults/critical", async (request, reply) => {
-    if (!authByApiKey(request, reply)) {
+    if (!hasValidApiKey(request)) {
       return reply.status(401).send({ message: "Unauthorized" });
     }
     const obj = parseJsonObject(request.body);
@@ -285,7 +280,7 @@ export const receiverRoutes: FastifyPluginAsync<ReceiverOptions> = async (
   });
 
   server.post("/faults", async (request, reply) => {
-    if (!authByApiKey(request, reply)) {
+    if (!hasValidApiKey(request)) {
       return reply.status(401).send({ message: "Unauthorized" });
     }
     const obj = parseJsonObject(request.body);
@@ -324,7 +319,7 @@ export const receiverRoutes: FastifyPluginAsync<ReceiverOptions> = async (
 
   server.post("/", async (request, reply) => {
     // API Key 검증
-    if (!authByApiKey(request, reply)) {
+    if (!hasValidApiKey(request)) {
       return reply.status(401).send({ message: "Unauthorized" });
     }
 
@@ -510,7 +505,7 @@ export const receiverRoutes: FastifyPluginAsync<ReceiverOptions> = async (
    * Auth: x-api-key (same as telemetry).
    */
   server.post("/settings", async (request, reply) => {
-    if (!authByApiKey(request, reply)) {
+    if (!hasValidApiKey(request)) {
       return reply.status(401).send({ message: "Unauthorized" });
     }
     const obj = parseJsonObject(request.body);
@@ -619,7 +614,7 @@ export const receiverRoutes: FastifyPluginAsync<ReceiverOptions> = async (
 
   // Device polling -> oldest pending command
   server.get("/commands", async (request, reply) => {
-    if (!authByApiKey(request, reply)) {
+    if (!hasValidApiKey(request)) {
       return reply.status(401).send({ message: "Unauthorized" });
     }
     const q = request.query as { installationId?: string; iccid?: string };
@@ -682,7 +677,7 @@ export const receiverRoutes: FastifyPluginAsync<ReceiverOptions> = async (
 
   // Device ACK
   server.post("/commands/ack", async (request, reply) => {
-    if (!authByApiKey(request, reply)) {
+    if (!hasValidApiKey(request)) {
       return reply.status(401).send({ message: "Unauthorized" });
     }
     const parsed = ackSchema.safeParse(request.body);

--- a/apps/backend/src/routes/receiver.ts
+++ b/apps/backend/src/routes/receiver.ts
@@ -240,6 +240,9 @@ export const receiverRoutes: FastifyPluginAsync<ReceiverOptions> = async (
 
   /* 더 구체적인 경로를 먼저 등록 (POST /faults 가 /faults/critical 을 가리지 않도록) */
   server.post("/faults/critical", async (request, reply) => {
+    if (!authByApiKey(request, reply)) {
+      return reply.status(401).send({ message: "Unauthorized" });
+    }
     const obj = parseJsonObject(request.body);
     if (!obj) {
       return reply.status(400).send({ message: "Invalid JSON body" });
@@ -282,6 +285,9 @@ export const receiverRoutes: FastifyPluginAsync<ReceiverOptions> = async (
   });
 
   server.post("/faults", async (request, reply) => {
+    if (!authByApiKey(request, reply)) {
+      return reply.status(401).send({ message: "Unauthorized" });
+    }
     const obj = parseJsonObject(request.body);
     if (!obj) {
       return reply.status(400).send({ message: "Invalid JSON body" });

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -53,16 +53,80 @@ const envSchema = z.object({
 
 export type Env = z.infer<typeof envSchema>;
 
+export class EnvConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "EnvConfigError";
+  }
+}
+
+/** 로컬 개발 편의용 폴백. 저장소에 공개된 값이므로 배포 환경에서는 사용을 금지한다. */
+const devFallbacks = {
+  DATABASE_URL: "postgresql://pmcs:pmcs@localhost:5432/pmcs",
+  JWT_SECRET: "change-me-in-production-min-32-chars!!",
+  RECEIVER_API_KEY: "receiver-dev-key",
+  FRONTEND_ORIGIN: "http://localhost:3000",
+} as const;
+
+type SecretName = keyof typeof devFallbacks;
+
+/** Railway 는 NODE_ENV 를 자동 주입하지 않는다 — NODE_ENV 만 보면 변수를 빼먹은 배포가
+ *  폴백값으로 조용히 떠버려 가드가 무력해지므로, Railway 주입 변수로도 배포를 판별한다. */
+const isDeployedEnv = (env: Record<string, string | undefined>) =>
+  env.NODE_ENV === "production" ||
+  Boolean(
+    env.RAILWAY_ENVIRONMENT ??
+      env.RAILWAY_ENVIRONMENT_NAME ??
+      env.RAILWAY_PROJECT_ID ??
+      env.RAILWAY_SERVICE_ID,
+  );
+
+const MISSING_ENV_HINT =
+  "  Railway → 해당 서비스 → Variables 에 설정하세요.\n" +
+  "  · dev/production 은 서비스가 분리돼 있으니 두 서비스를 모두 확인할 것\n" +
+  "  · project Shared Variables 에만 넣었다면 서비스에서 ${{shared.NAME}} 로 참조해야 적용됨\n" +
+  "  · 시크릿 생성: openssl rand -hex 24";
+
 export const parseEnv = (env: Record<string, string | undefined>) => {
-  return envSchema.parse({
+  const deployed = isDeployedEnv(env);
+  const fallbacksUsed: SecretName[] = [];
+
+  const requireSecret = (name: SecretName): string => {
+    const value = env[name]?.trim() ?? "";
+    if (!deployed) {
+      if (value) return value;
+      fallbacksUsed.push(name);
+      return devFallbacks[name];
+    }
+    if (!value) {
+      throw new EnvConfigError(
+        `${name} 가 비어 있습니다 — 배포 환경에서는 필수입니다.\n${MISSING_ENV_HINT}`,
+      );
+    }
+    if (value === devFallbacks[name]) {
+      throw new EnvConfigError(
+        `${name} 가 개발용 기본값 그대로입니다 — 저장소에 공개된 값이라 인증이 없는 것과 같습니다.\n${MISSING_ENV_HINT}`,
+      );
+    }
+    return value;
+  };
+
+  const parsed = envSchema.parse({
     PORT: Number(env.PORT ?? "4000"),
     HOST: env.HOST ?? "0.0.0.0",
-    DATABASE_URL:
-      env.DATABASE_URL ?? "postgresql://pmcs:pmcs@localhost:5432/pmcs",
-    JWT_SECRET: env.JWT_SECRET ?? "change-me-in-production-min-32-chars!!",
-    RECEIVER_API_KEY: env.RECEIVER_API_KEY ?? "receiver-dev-key",
-    FRONTEND_ORIGIN: env.FRONTEND_ORIGIN ?? "http://localhost:3000",
+    DATABASE_URL: requireSecret("DATABASE_URL"),
+    JWT_SECRET: requireSecret("JWT_SECRET"),
+    RECEIVER_API_KEY: requireSecret("RECEIVER_API_KEY"),
+    FRONTEND_ORIGIN: requireSecret("FRONTEND_ORIGIN"),
   });
+
+  if (fallbacksUsed.length > 0) {
+    console.warn(
+      `⚠️  개발용 폴백값 사용 중 (로컬 전용): ${fallbacksUsed.join(", ")}`,
+    );
+  }
+
+  return parsed;
 };
 
 export const buildServer = async (env: Env) => {

--- a/apps/backend/src/services/deviceService.ts
+++ b/apps/backend/src/services/deviceService.ts
@@ -261,7 +261,7 @@ export type ReceiverIdentityResolution = {
  */
 /**
  * ICCID로 Installation·Device 보장 (미등록 시 unknown 사이트에 자동 생성).
- * POST /receiver/faults* 전용 — API 키 없이 ICCID만으로 수신할 때 사용.
+ * POST /receiver/faults* — 미등록 ICCID 자동 프로비저닝용 (수신 라우트는 x-api-key 필수).
  */
 export const getInstallationIdByIccid = async (
   iccidRaw: string,


### PR DESCRIPTION
## Summary
- Require `x-api-key` (`RECEIVER_API_KEY`) on `POST /receiver/faults` and `POST /receiver/faults/critical`, matching telemetry and command poll auth
- Update README device-auth list and remove the outdated “API key optional” comment on auto-provision

## Why
Unauthenticated fault POSTs let anyone inject RAISE/CLEAR states and spam the critical webhook/WS channel.

## Ops note
HMI firmware that posts faults must send the same `x-api-key` header already used for `POST /receiver`. Deploy after confirming devices have the key configured.

## Test plan
- [ ] `POST /receiver/faults` without `x-api-key` → 401
- [ ] `POST /receiver/faults/critical` without `x-api-key` → 401
- [ ] Same endpoints with valid `x-api-key` → 201 and DB upsert as before
- [ ] Admin UI fault history (GET via JWT) still works
- [ ] Confirm field HMI sends `x-api-key` on fault posts before merging to prod


Made with [Cursor](https://cursor.com)