### PR TITLE
fix: only reject dev fallback values for actual secrets

### DIFF
--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -91,7 +91,10 @@ export const parseEnv = (env: Record<string, string | undefined>) => {
   const deployed = isDeployedEnv(env);
   const fallbacksUsed: SecretName[] = [];
 
-  const requireSecret = (name: SecretName): string => {
+  const readRequired = (
+    name: SecretName,
+    rejectFallbackValue: boolean,
+  ): string => {
     const value = env[name]?.trim() ?? "";
     if (!deployed) {
       if (value) return value;
@@ -103,7 +106,7 @@ export const parseEnv = (env: Record<string, string | undefined>) => {
         `${name} 가 비어 있습니다 — 배포 환경에서는 필수입니다.\n${MISSING_ENV_HINT}`,
       );
     }
-    if (value === devFallbacks[name]) {
+    if (rejectFallbackValue && value === devFallbacks[name]) {
       throw new EnvConfigError(
         `${name} 가 개발용 기본값 그대로입니다 — 저장소에 공개된 값이라 인증이 없는 것과 같습니다.\n${MISSING_ENV_HINT}`,
       );
@@ -111,13 +114,18 @@ export const parseEnv = (env: Record<string, string | undefined>) => {
     return value;
   };
 
+  const requireSecret = (name: SecretName) => readRequired(name, true);
+  /** 시크릿이 아니므로 값 자체는 검사하지 않는다 — dev 백엔드가 localhost 를 허용 origin 으로
+   *  두는 것은 정상 설정이다. 누락만 잡는다. */
+  const requireConfig = (name: SecretName) => readRequired(name, false);
+
   const parsed = envSchema.parse({
     PORT: Number(env.PORT ?? "4000"),
     HOST: env.HOST ?? "0.0.0.0",
     DATABASE_URL: requireSecret("DATABASE_URL"),
     JWT_SECRET: requireSecret("JWT_SECRET"),
     RECEIVER_API_KEY: requireSecret("RECEIVER_API_KEY"),
-    FRONTEND_ORIGIN: requireSecret("FRONTEND_ORIGIN"),
+    FRONTEND_ORIGIN: requireConfig("FRONTEND_ORIGIN"),
   });
 
   if (fallbacksUsed.length > 0) {

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -81,6 +81,13 @@ const isDeployedEnv = (env: Record<string, string | undefined>) =>
       env.RAILWAY_SERVICE_ID,
   );
 
+/** 대시보드에는 변수가 보이는데 프로세스에는 없는 가장 흔한 원인 — 이름에 공백·탭이 섞여
+ *  `RECEIVER_API_KEY\t` 로 저장된 경우. UI 에서는 정상으로 보여 찾는 데 오래 걸린다. */
+const findWhitespacePaddedName = (
+  env: Record<string, string | undefined>,
+  name: string,
+) => Object.keys(env).find((key) => key !== name && key.trim() === name);
+
 const MISSING_ENV_HINT =
   "  Railway → 해당 서비스 → Variables 에 설정하세요.\n" +
   "  · dev/production 은 서비스가 분리돼 있으니 두 서비스를 모두 확인할 것\n" +
@@ -102,8 +109,13 @@ export const parseEnv = (env: Record<string, string | undefined>) => {
       return devFallbacks[name];
     }
     if (!value) {
+      const paddedName = findWhitespacePaddedName(env, name);
       throw new EnvConfigError(
-        `${name} 가 비어 있습니다 — 배포 환경에서는 필수입니다.\n${MISSING_ENV_HINT}`,
+        `${name} 가 비어 있습니다 — 배포 환경에서는 필수입니다.\n` +
+          (paddedName
+            ? `  이름에 공백/탭이 섞인 ${JSON.stringify(paddedName)} 가 대신 설정돼 있습니다.\n` +
+              `  대시보드에서는 똑같아 보이니 해당 변수를 지우고 이름을 다시 입력하세요.`
+            : MISSING_ENV_HINT),
       );
     }
     if (rejectFallbackValue && value === devFallbacks[name]) {


### PR DESCRIPTION
## Summary
- `FRONTEND_ORIGIN` is not a secret, and a dev backend allowing `http://localhost:3000` is a legitimate setting. Matching the dev fallback value no longer blocks a deploy for it.
- Missing values still fail boot for all four required variables (`DATABASE_URL`, `JWT_SECRET`, `RECEIVER_API_KEY`, `FRONTEND_ORIGIN`).
- Dev fallback *values* are still rejected for the real secrets.

Follow-up to #73, which made the dev Railway deploy fail on purpose because a required variable never reaches the container.

## Test plan
- [x] `parseEnv` cases: deployed + `FRONTEND_ORIGIN=http://localhost:3000` passes, missing value fails, `RECEIVER_API_KEY` missing fails, `RECEIVER_API_KEY=receiver-dev-key` fails, all-set passes
- [x] `yarn workspace @pmcs/backend typecheck`
- [ ] dev deploy boots once Railway variables are confirmed

Made with [Cursor](https://cursor.com)