### PR TITLE
fix: unblock Railway build after ICCID nullable narrow

### DIFF
--- a/apps/backend/src/services/deviceService.ts
+++ b/apps/backend/src/services/deviceService.ts
@@ -668,7 +668,7 @@ export const deviceService = {
       iccid === null || iccid === undefined || String(iccid).trim() === ""
         ? null
         : normalizeIccid(iccid);
-    if (norm === "") {
+    if (!norm) {
       await prisma.installation.update({
         where: { id: installationId },
         data: { iccid: null },


### PR DESCRIPTION
## Summary
- Follow-up to #76: narrow `norm` with `if (!norm)` so `iccidConflictWhere` gets `string` (fixes TS2345 that broke Docker/Railway build)

## Test plan
- [ ] CI docker build / typecheck green
- [ ] Railway DEV/PROD redeploy succeeds

Made with [Cursor](https://cursor.com)